### PR TITLE
Add basic CDJ-3000 information

### DIFF
--- a/doc/modules/ROOT/pages/packets.adoc
+++ b/doc/modules/ROOT/pages/packets.adoc
@@ -109,6 +109,11 @@ information about the media that has been mounted in a particular
 slot. They also support remote-control features such as instructing
 players to load tracks.
 
+=== Port 50004 Packets
+
+Packets sent to port 50004 provide link cue audio data between supported
+players and mixers.
+
 
 [cols=">1m,<14"]
 |===

--- a/doc/modules/ROOT/pages/packets.adoc
+++ b/doc/modules/ROOT/pages/packets.adoc
@@ -100,6 +100,7 @@ out), and mixer features like Fader Start and Channels On Air.
 
 |===
 
+
 === Port 50002 Packets
 
 Packets sent to port 50002 provide more detailed device status (they
@@ -122,6 +123,7 @@ players to load tracks.
 |34 |<<loading_tracks.adoc#loading-settings,Load Settings Command>>
 
 |===
+
 
 === Port 50004 Packets
 

--- a/doc/modules/ROOT/pages/packets.adoc
+++ b/doc/modules/ROOT/pages/packets.adoc
@@ -109,12 +109,6 @@ information about the media that has been mounted in a particular
 slot. They also support remote-control features such as instructing
 players to load tracks.
 
-=== Port 50004 Packets
-
-Packets sent to port 50004 provide link cue audio data between supported
-players and mixers.
-
-
 [cols=">1m,<14"]
 |===
 |Kind |Purpose
@@ -128,3 +122,9 @@ players and mixers.
 |34 |<<loading_tracks.adoc#loading-settings,Load Settings Command>>
 
 |===
+
+=== Port 50004 Packets
+
+Packets sent to port 50004 provide link cue audio data between supported
+players and mixers.
+

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -206,14 +206,14 @@ These use yet another packet structure variant following the device
 name. As always the byte after the name has the value `01`, but the
 subtype value which follows that (at byte{nbsp}``20``) has the value
 `03` here, rather than `00` as we saw in the mixer status packets.
+Values of `03`, `04` and `06` have been seen which may indicate this
+byte represents the protocol or packet version.
 
 Packets of subtype `03` seem structurally equivalent to subtype `00`
 however: the subtype indicator is followed by the Device Number _D_ at
 byte{nbsp}``21`` and a length-remaining value _len~r~_ at
 bytes{nbsp}``22``–`23`. If anyone can think of a reason why these
-packets don’t simply reuse subtype `00`, please share it! Packets of
-subtype `03`, `04` and `06` have been seen which may indicate
-the protocol or packet version.
+packets don’t simply reuse subtype `00`, please share it!
 
 The Device Number in _D_ (bytes{nbsp}``21`` and `24`) is the Player
 Number as displayed on the CDJ itself. In the case of this capture,

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -206,11 +206,14 @@ These use yet another packet structure variant following the device
 name. As always the byte after the name has the value `01`, but the
 subtype value which follows that (at byte{nbsp}``20``) has the value
 `03` here, rather than `00` as we saw in the mixer status packets.
+
 Packets of subtype `03` seem structurally equivalent to subtype `00`
 however: the subtype indicator is followed by the Device Number _D_ at
 byte{nbsp}``21`` and a length-remaining value _len~r~_ at
 bytes{nbsp}``22``–`23`. If anyone can think of a reason why these
-packets don’t simply reuse subtype `00`, please share it!
+packets don’t simply reuse subtype `00`, please share it! Packets of
+subtype `03`, `04` and `06` have been seen which may indicate
+the protocol or packet version.
 
 The Device Number in _D_ (bytes{nbsp}``21`` and `24`) is the Player
 Number as displayed on the CDJ itself. In the case of this capture,

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -547,10 +547,13 @@ next cue point (if any) in the track.
 Bytes `c8`-`cb` seem to contain a 4-byte packet counter labeled
 _Packet_, which is incremented for each packet sent by the player. (I
 am just guessing it is four bytes long, I have not yet watched long
-enough for the count to need more than the last three bytes).
+enough for the count to need more than the last three bytes). Some
+players do not seem to increment the counter, e.g. CDJ-3000 is fixed
+at `00 00 00 00`. Counters are instead seen incrementing in packets
+sent over UDP port 50004.
 
 Byte `cc`, labeled _nx_, seems to have the value `0f` for nexus
-players, `1f` for the XDJ-XZ, and `05` for older players.
+players, `1f` for the XDJ-XZ and CDJ-3000, and `05` for older players.
 
 [[rekordbox-status-packets]]
 == Rekordbox Status packets

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -138,7 +138,8 @@ shown below (for nexus players). Older players send `d0`-byte packets
 with slightly less information (notably the current beat number is not
 available, so it is impossible to interpolate playback position to
 calculate a virtual timecode value). Newer firmware and Nexus 2
-players send packets that are `11c` or `124` bytes long.
+players send packets that are `11c` or `124` bytes long. CDJ-3000
+devices send packets that are `200` bytes long.
 
 [[cdj-status-packet]]
 .CDJ status packet.

--- a/src/dysentery/view.clj
+++ b/src/dysentery/view.clj
@@ -73,7 +73,7 @@
   (let [current-type (get packet 10)]
     (if (= current-type expected-type)
       (case expected-type
-        0x0a (correct-length? packet #{208 212 284 292})
+        0x0a (correct-length? packet #{208 212 284 292 512})
         0x29 (correct-length? packet #{56})
         0x19 (correct-length? packet #{0x58})
         0x05 (correct-length? packet #{48})


### PR DESCRIPTION
- Add some basic information about CDJ-3000.
- Accept 512 byte packets in dysentery to prevent warnings (fixes #27)

Feel free to re-jig wording, etc as necessary.
Will add more PRs as I go.

Thanks again for all your hard work on dysentery!