### PR TITLE
Add Absolute Position packet analysis

### DIFF
--- a/doc/modules/ROOT/examples/status_shared.edn
+++ b/doc/modules/ROOT/examples/status_shared.edn
@@ -13,7 +13,7 @@
   "Generates the byte labels and first two rows of a standard DJ Link
   status, beat, or control packet with the specified `kind` byte."
   ([kind]
-   (draw-packet-header kind 0))
+   (draw-packet-header kind 1))
   ([kind subtype]
    (draw-column-headers)
    (draw-related-boxes [0x51 0x73 0x70 0x74 0x31 0x57 0x6d 0x4a 0x4f 0x4c (hex-text kind 2 :bold)]

--- a/doc/modules/ROOT/examples/status_shared.edn
+++ b/doc/modules/ROOT/examples/status_shared.edn
@@ -12,10 +12,12 @@
 (defn draw-packet-header
   "Generates the byte labels and first two rows of a standard DJ Link
   status, beat, or control packet with the specified `kind` byte."
-  [kind]
-  (draw-column-headers)
-  (draw-related-boxes [0x51 0x73 0x70 0x74 0x31 0x57 0x6d 0x4a 0x4f 0x4c (hex-text kind 2 :bold)]
-                      :bg-green)
-  (draw-box nil [{:span 5} :box-above])
-  (draw-box (text "Device Name (padded with " :plain [:hex "00"] ")") [{:span 15} :box-below])
-  (draw-box 1))
+  ([kind]
+   (draw-packet-header kind 0))
+  ([kind subtype]
+   (draw-column-headers)
+   (draw-related-boxes [0x51 0x73 0x70 0x74 0x31 0x57 0x6d 0x4a 0x4f 0x4c (hex-text kind 2 :bold)]
+                       :bg-green)
+   (draw-box nil [{:span 5} :box-above])
+   (draw-box (text "Device Name (padded with " :plain [:hex "00"] ")") [{:span 15} :box-below])
+   (draw-box subtype)))

--- a/doc/modules/ROOT/pages/beats.adoc
+++ b/doc/modules/ROOT/pages/beats.adoc
@@ -182,11 +182,11 @@ down to the nearest second.
 
 _Playhead_ reports the absolute position of the playhead in milliseconds.
 
-_Pitch_ is a 32-bit signed integer representing absolute value of pitch
-slider multiplied by `64`. For example, if the pitch slider is at 3.26%,
-this value is `0146` (326 in decimal).
+_Pitch_ is a 32-bit signed integer representing the value of the pitch
+slider as shown on the player screen multiplied by `64`. For example,
+if the pitch slider is at 3.26%, this value is `0146` (326 in decimal).
 
-_BPM_ reports the absolute BPM value multiplied by `0a`. For example
-120.2BPM is represented as `4b2` (1202 in decimal). Tracks with unknown
-BPM have the value `ffffffff`.
+_BPM_ reports the BPM value as shown on the player screen multiplied by
+`0a`. For example 120.2BPM is represented as `4b2` (1202 in decimal).
+Tracks with unknown BPM have the value `ffffffff`.
 

--- a/doc/modules/ROOT/pages/beats.adoc
+++ b/doc/modules/ROOT/pages/beats.adoc
@@ -146,3 +146,47 @@ The counter _B~b~_ at byte{nbsp}``5c`` counts out the beat within each
 bar, cycling 1 → 2 → 3 → 4 repeatedly, and can be used to identify the
 down beat if it is coming from the master player (and if the DJ has
 properly established the track's beat grid).
+
+[[absolute-position-packet]]
+== Absolute Position Packets
+
+Known devices which send Absolute Position Packets include the CDJ-3000.
+
+Absolute Position Packets are only transmitted while a track is loaded on
+a player. This packet is sent to all connected devices on port 50001 every
+30 milliseconds.
+
+.Absolute Position packet.
+[bytefield]
+----
+include::example$status_shared.edn[]
+
+(draw-packet-header 0x0b 2)
+
+(draw-boxes [(hex-text 0 2 :bold) (text "D" :math)])
+(draw-box (text "len" :math [:sub "r"]) {:span 2})
+(draw-box (text "TrackLength" :math) {:span 4})
+(draw-box (text "Playhead" :math) {:span 4})
+(draw-box (text "Pitch" :math) {:span 4})
+(draw-related-boxes (repeat 8 0x00))
+(draw-box (text "BPM" :math) {:span 4})
+----
+
+_D_ indicates the number of the player sending the packet.
+
+_len~r~_ reports the length of the rest of the packet, in other words,
+the number of bytes which come after _len~r~_.
+
+_TrackLength_ reports the length of the loaded track in seconds, rounded
+down to the nearest second.
+
+_Playhead_ reports the absolute position of the playhead in milliseconds.
+
+_Pitch_ is a 32-bit signed integer representing absolute value of pitch
+slider multiplied by `64`. For example, if the pitch slider is at 3.26%,
+this value is `0146`.
+
+_BPM_ reports the absolute BPM value multiplied by `0a`. For example
+120.2BPM is represented as `4b2`. Tracks with unknown BPM have the value
+`ffffffff`.
+

--- a/doc/modules/ROOT/pages/beats.adoc
+++ b/doc/modules/ROOT/pages/beats.adoc
@@ -150,9 +150,9 @@ properly established the track's beat grid).
 [[absolute-position-packet]]
 == Absolute Position Packets
 
-Known devices which send Absolute Position Packets include the CDJ-3000.
+Known devices which send Absolute Position packets include the CDJ-3000.
 
-Absolute Position Packets are only transmitted while a track is loaded on
+Absolute Position packets are only transmitted while a track is loaded on
 a player. This packet is sent to all connected devices on port 50001 every
 30 milliseconds.
 
@@ -184,9 +184,9 @@ _Playhead_ reports the absolute position of the playhead in milliseconds.
 
 _Pitch_ is a 32-bit signed integer representing absolute value of pitch
 slider multiplied by `64`. For example, if the pitch slider is at 3.26%,
-this value is `0146`.
+this value is `0146` (326 in decimal).
 
 _BPM_ reports the absolute BPM value multiplied by `0a`. For example
-120.2BPM is represented as `4b2`. Tracks with unknown BPM have the value
-`ffffffff`.
+120.2BPM is represented as `4b2` (1202 in decimal). Tracks with unknown
+BPM have the value `ffffffff`.
 

--- a/doc/modules/ROOT/pages/packets.adoc
+++ b/doc/modules/ROOT/pages/packets.adoc
@@ -93,6 +93,7 @@ out), and mixer features like Fader Start and Channels On Air.
 
 |02 |<<mixer_integration.adoc#fader-start,Fader Start>>
 |03 |<<mixer_integration.adoc#channels-on-air,Channels On Air>>
+|0b |<<beats.adoc#absolute-position-packet,Absolute Position>>
 |26 |<<sync.adoc#tempo-master-handoff,Master Handoff Request>>
 |27 |<<sync.adoc#master-takeover-response-packet,Master Handoff Response>>
 |28 |<<beats.adoc#beat-packets,Beat>>


### PR DESCRIPTION
Here's another one:
- Add Absolute Position (`0x0b`) packet analysis

Much simpler way to keep track of fine grained Track Position, BPM and Pitch Slider values ;)
I didn't know which file to stash this under so put it in `beats.adoc`, feel free to re-jig as necessary!