### PR TITLE
Document CDJ-3000 streaming protocol and .2EX vocal detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ played on CDJs.
 > * [prolink-go](https://github.com/EvanPurkhiser/prolink-go)
 > * [python-prodj-link](https://github.com/flesniak/python-prodj-link)
 > * [prolink-cpp](https://github.com/grantHarris/prolink-cpp)
+> * [Now Playing](https://nowplayingapp.com)
 
 You can run dysentery and look at what it finds on your network by
 just downloading and executing the jar, though, and we hope you will,

--- a/doc/modules/ROOT/pages/media.adoc
+++ b/doc/modules/ROOT/pages/media.adoc
@@ -95,9 +95,11 @@ In other words, it will have the value `01` when a rekordbox database is present
 The value _set_ at byte{nbsp}``ab`` indicates whether there is a “My Settings” file present on the media.
 If it has a non-zero value, when the user links to that media (or navigates to its root menu), the player will pop up an alert saying to press the *Menu* button to load *My Settings* (which allows the player configuration to be quickly restored to the DJ’s preferred state).
 
-> The actual settings are found in the `/PIONEER/` folder at the root of the mounted media, in the files `MYSETTING.DAT`, `MYSETTING2.DAT`, and `DEVSETTING.DAT`.
-> The DJ’s Kuvo profile information is in the same folder, in the file `djprofile.nxs.`
-> The details of these files have not yet been explored.
+> The actual settings are found in the `/PIONEER/` folder at the root of the mounted media, in the files `MYSETTING.DAT`, `MYSETTING2.DAT`, `DJMMYSETTING.DAT`, and `DEVSETTING.DAT`.
+> The DJ's Kuvo profile information is in the same folder, in the file `djprofile.nxs`.
+>
+> When a USB stick has been authorized for Cloud Direct Play (CDP) in rekordbox, the `/PIONEER/CDP/` directory will also be present, containing authentication files (`ak.dat` and `nn.dat`) that the CDJ reads to authenticate with Pioneer's cloud service at `cloud.kuvo.com`.
+> A `.CacheData/CloudTemp/` directory is also prepared as a cache for streaming content downloaded during playback.
 
 The number of rekordbox playlists present on the media (also zero if there is no rekordbox database) is found at bytes{nbsp}``ae`` and `af`.
 

--- a/doc/modules/ROOT/pages/track_metadata.adoc
+++ b/doc/modules/ROOT/pages/track_metadata.adoc
@@ -941,6 +941,7 @@ Each pair of bytes encodes the height of the waveform at that segment as a five 
 
 With the help of some https://github.com/Deep-Symmetry/dysentery/issues/33[additional
 analysis] we know now how to request and interpret the 3-band style waveforms introduced with the CDJ-3000.
+The `.2EX` file also contains a <<requesting-vocal-config,vocal detection configuration>> tag (`PWVC`).
 
 Both the 3-band waveform preview and detail are requested using variations on the <<requesting-new-tags,same request type>>, which asks for specific content from the `ANLZ0000.2EX` file created by rekordbox.
 The https://github.com/Deep-Symmetry/crate-digger[Crate Digger project] which has its own
@@ -1045,6 +1046,49 @@ The colors for low, mid-range, and high frequencies are the same as in the previ
 The area where low and mid-range frequencies overlap is drawn in brown, and their pure colors are seen where there is no overlap.
 The white high frequency is drawn last so it obscures any low or mid-range information underneath it.
 Recordbox actually seems to do some light blending, but it is so dim that we have not bothered to reproduce it so far.
+
+[#requesting-vocal-config]
+== Requesting Vocal Detection Configuration
+
+The `.2EX` analysis file also contains a `PWVC` tag (tag code `0x50575643`) that stores vocal detection configuration for the track.
+This tag contains threshold values that rekordbox uses to classify frequency content as vocal or non-vocal.
+Like the 3-band waveforms, it can be requested using the <<requesting-new-tags,general tag request mechanism>>.
+
+To request the vocal configuration of a track, send a message with _type_ `2c04` containing the _rekordbox_ ID of the track, the tag type identifier `PWVC` and the file extension identifier `2EX` encoded as four-byte numbers, holding the ASCII in big-endian (backwards) order:
+
+.Vocal config request message.
+[bytefield]
+----
+include::example$dbserver_shared.edn[]
+(draw-remotedb-header 0x2c04 6 6 6 6)
+(draw-dmst-field 1)
+(draw-number-field (text "rekordbox" :math))
+(draw-related-boxes [0x11 0x43 0x56 0x57 0x50])
+(draw-related-boxes [0x11 0x00 0x58 0x45 0x32])
+----
+
+As usual, _TxID_ should be incremented each time you send a query, and will be used to identify the response messages.
+_D_ should have the same value you used in your initial query context setup packet, identifying the device that is asking the question.
+_S~r~_ and _T~r~_ are the slot in which the track being asked about can be found and its
+track type; each has the same values used in xref:vcdj.adoc#cdj-status-packet[CDJ status packets].
+_rekordbox_ identifies the specific track whose analysis you are requesting, as found in a CDJ status packet or playlist response, and the final two numeric arguments specify that you are interested in the `PWVC` tag (which holds the vocal detection configuration) from the track's `2EX` extended analysis file.
+
+The response follows the same <<requesting-new-tags,analysis tag response>> format, with _type_ `4f02`.
+The vocal configuration data begins at byte `34` and has the following structure:
+
+.Vocal config data.
+[bytefield]
+----
+(draw-column-headers)
+(draw-related-boxes (repeat 2 nil))
+(draw-box (text "thr" :math [:sub "low"]) {:span 2})
+(draw-box (text "thr" :math [:sub "mid"]) {:span 2})
+(draw-box (text "thr" :math [:sub "high"]) {:span 2})
+----
+
+The first two bytes have an unknown purpose (always observed as zero).
+_thr~low~_, _thr~mid~_, and _thr~high~_ are each two-byte big-endian unsigned integers containing the vocal detection thresholds for the low, mid-range, and high frequency bands respectively.
+Across 192 analyzed tracks, observed threshold ranges are: _thr~low~_ 80–114, _thr~mid~_ 80–146, _thr~high~_ 98–159.
 
 [#requesting-cues]
 == Requesting Cue Points and Loops

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -225,16 +225,49 @@ When a track is loaded, the device from which the track was loaded is reported i
 When no track is loaded, _D~r~_ has the value `00`.
 
 [#slot-identifiers]
-Similarly, _S~r~_ at byte{nbsp}``29`` reports the slot from which the track was loaded: the value `00` means no track is loaded, `01` means the CD drive, `02` means the SD slot, and `03` means the USB slot.
-When a track is loaded from a rekordbox collection on a laptop, _S~r~_ has the value `04`.
+Similarly, _S~r~_ at byte{nbsp}``29`` reports the slot from which the track was loaded:
 
-_T~r~_ at byte{nbsp}``2a`` indicates the track type.
-It has the value `00` when no track is loaded, `01` when a rekordbox track is loaded, `02` when an unanalyzed track is loaded (from a media slot without a rekordbox database, including from a data disc), and `05` when an audio CD track is loaded.
+[#known-sr-values]
+.Known _S~r~_ values.
+[cols=">1m,<12"]
+|===
+|Value |Slot
+
+|00 |No track is loaded.
+|01 |CD drive.
+|02 |SD slot.
+|03 |USB slot.
+|04 |rekordbox collection on a laptop.
+|05 |Unknown (possibly a streaming service).
+|06 |Streaming Direct Play.
+|07 |USB 2 (XDJ-AZ in four-deck mode).
+|08 |Unknown (possibly a streaming service).
+|09 |Beatport LINK streaming.
+|===
 
 NOTE: The XDJ-XZ presents an unusual situation because it embodies two separate players and a mixer all sharing the same IP address.
 Because of limitations in the protocol, that means it can only offer one pair of slots to the network, so its two USB slots are represented as though they belong to player 1.
 The slot labeled USB 1 is treated on the network as the SD slot, and the slot labeled USB 2 as the USB slot.
 The XDJ-AZ behaves the same way in Pro DJ Link mode, but in four-deck mode it uses a new _S~r~_ value of `07` to represent a track loaded from USB 2.
+
+NOTE: Slot values `06` and `09` have been observed on CDJ-3000 hardware when tracks are loaded from streaming services (Streaming Direct Play and Beatport LINK, respectively).
+Slot values `05`, `07`, and `08` may correspond to other streaming services such as TIDAL, Apple Music, or SoundCloud Go, but this has not yet been confirmed.
+When a streaming track is loaded, the _rekordbox_ field at bytes{nbsp}``2c``–`2f` contains an internal CDJ index rather than a catalog ID from the streaming service.
+
+_T~r~_ at byte{nbsp}``2a`` indicates the track type:
+
+[#known-tr-values]
+.Known _T~r~_ values.
+[cols=">1m,<12"]
+|===
+|Value |Track type
+
+|00 |No track is loaded.
+|01 |rekordbox track.
+|02 |Unanalyzed track (from a media slot without a rekordbox database, including from a data disc).
+|05 |Audio CD track.
+|06 |Streaming track (loaded from a streaming service such as Beatport LINK or Streaming Direct Play).
+|===
 
 The field _rekordbox_ at bytes{nbsp}``2c``–`2f` contains the rekordbox database ID of the loaded track when a rekordbox track is being played.
 When a non-rekordbox track is loaded from a media slot, this field still holds a unique ID by which the track can be identified for metadata requests, and when an audio CD track is loaded, this is just the track number.

--- a/doc/modules/ROOT/pages/vcdj.adoc
+++ b/doc/modules/ROOT/pages/vcdj.adoc
@@ -253,6 +253,7 @@ The XDJ-AZ behaves the same way in Pro DJ Link mode, but in four-deck mode it us
 NOTE: Slot values `06` and `09` have been observed on CDJ-3000 hardware when tracks are loaded from streaming services (Streaming Direct Play and Beatport LINK, respectively).
 Slot values `05`, `07`, and `08` may correspond to other streaming services such as TIDAL, Apple Music, or SoundCloud Go, but this has not yet been confirmed.
 When a streaming track is loaded, the _rekordbox_ field at bytes{nbsp}``2c``–`2f` contains an internal CDJ index rather than a catalog ID from the streaming service.
+CDJ-3000 supports two separate streaming systems: **Cloud Direct Play** (CDP), which streams from the DJ's personal rekordbox library via `cloud.kuvo.com` — inserting a USB stick with credential files under `/PIONEER/CDP/` allows the CDJ to authenticate automatically without requiring the DJ to enter a username and password — and **Beatport LINK**, which accesses Beatport's streaming catalog and requires the DJ to log in on the CDJ touchscreen each time.
 
 _T~r~_ at byte{nbsp}``2a`` indicates the track type:
 


### PR DESCRIPTION
- Document streaming media slot values (`0x06` Streaming Direct Play, `0x09` Beatport LINK)
   and track type `0x06` for streaming tracks, observed on CDJ-3000 hardware. Convert inline slot and track
  type descriptions to tables for clarity.
- Document the two separate streaming systems: Cloud Direct Play (authenticates via USB credential files
  under `/PIONEER/CDP/`) and Beatport LINK (requires touchscreen login each time). Add CDP cache directory and
   `DJMMYSETTING.DAT` to USB media structure.
- Document the previously undiscovered PWVC vocal detection configuration tag found in `.2EX` analysis
  files.
- Add Now Playing to the list of related projects.