### PR TITLE
stream start message & audio path menu item type

### DIFF
--- a/doc/modules/ROOT/pages/menus.adoc
+++ b/doc/modules/ROOT/pages/menus.adoc
@@ -70,6 +70,7 @@ The menus available to you will be returned as entries in the root menu response
 |1105 |xref:track_metadata.adoc#playlist-requests[Playlist Menu] | _r:m:s:t_, sort, playlist or folder id, type (0:playlist, 1:folder)
 |1300 |Search by substring | _r:m:s:t_, sort, search string byte size, search string (uppercase), unknown (0)
 |2006 |Folder Menu | _r:m:s:t_, sort?, folder id, unknown (0)
+|2102 |Track Stream Start | _r:m:s:t_, track ID
 |===
 
 The first argument to every menu request is a four-byte number where each byte means something different.

--- a/doc/modules/ROOT/pages/track_metadata.adoc
+++ b/doc/modules/ROOT/pages/track_metadata.adoc
@@ -441,6 +441,7 @@ The meanings we have identified so far are:
 |===
 |Type |Meaning
 
+|0000 |Audio Path (seen in stream start menus)
 |0001 |Folder (such as in the playlists menu)footnote:[A nested list of playlists rather than an individual playlist.]
 |0002 |Album title
 |0003 |Disc


### PR DESCRIPTION
note: last one i opened had some weird auto review thing happen, which i thought was annoying so i found how to disable it and am trying again. all hardware involved in testing these assumptions are XDJ-1000mk2 units

# Stream Start Messages

These are sent by the player when you press the menu button down on a track over the Link, to try to load it from the other player.

here's one dissected in wireshark using my [DJ Link dissector](https://tangled.org/piss.beauty/djlink-dissector) (8450 = `0x2102`, the message type)
<img width="435" height="259" alt="image" src="https://github.com/user-attachments/assets/99aedb86-0dec-470f-870c-854e3ad229c4" />

and its corresponding payload as a hex dump

```
0000   11 87 23 49 ae 11 05 c0 00 29 10 21 02 0f 02 14
0010   00 00 00 0c 06 06 00 00 00 00 00 00 00 00 00 00
0020   11 02 08 03 01 11 00 00 01 5a
```
 
 ## Response
 
 I didn't see a place to document the menu response the stream start query expects once it calls `RenderMenu`, but it's 6 menu items with the following types:
 ```
 [ TrackTitle, Duration, Tempo, Comment, Audio Path (0x0000), Unknown (0x002f) ]
 ```
 
 i don't know if the last argument is ever of a different type than `0x002f`, since i don't know its meaning.
 
 this response is the reason i'm documenting that `0x0000` gets used for audio paths.
 
 # AudioPath menu item type
 
 Appears in rendered menus for stream start requests, as the 5th item. 
 Seems necessary for players to conduct a handoff to streaming the track from the NFSv2 mount.
 
 here's a hex dump of one (just the MenuItem, nothing else) where the returned audio path is: 
 `/Contents/Kraftwerk/Trans-Europe Express/06 - Abzug.mp3`
 
 ```
 0000   11 87 23 49 ae 11 05 c0 00 2a 10 41 01 0f 0c 14
0010   00 00 00 0c 06 06 06 02 06 02 06 06 06 06 06 06
0020   11 00 c0 33 27 11 00 00 01 5a 11 00 00 00 70 26
0030   00 00 00 38 00 2f 00 43 00 6f 00 6e 00 74 00 65
0040   00 6e 00 74 00 73 00 2f 00 4b 00 72 00 61 00 66
0050   00 74 00 77 00 65 00 72 00 6b 00 2f 00 54 00 72
0060   00 61 00 6e 00 73 00 2d 00 45 00 75 00 72 00 6f
0070   00 70 00 65 00 20 00 45 00 78 00 70 00 72 00 65
0080   00 73 00 73 00 2f 00 30 00 36 00 20 00 2d 00 20
0090   00 41 00 62 00 7a 00 75 00 67 00 2e 00 6d 00 70
00a0   00 33 00 00 11 00 00 00 02 26 00 00 00 01 00 00
00b0   11 00 00 00 00 11 00 00 00 00 11 00 00 00 00 11
00c0   00 00 00 00 11 00 00 00 00 11 00 00 00 00
```